### PR TITLE
Documenting that new required fields are breaking changes

### DIFF
--- a/FAQs/Schema FAQ.md
+++ b/FAQs/Schema FAQ.md
@@ -158,13 +158,14 @@ So any version in the 1.x line should be backwards-compatible with previous 1.x 
 ## What changes are not backwards compatible?
 
 1. The removal of an event, object, attribute, data type, or enum member.
-  1. The `name` of an event or object is missing in the NEW schema.
-  2. The dictionary key of an attribute or data type (its implied `name`) is missing in the NEW schema.
-  3. The dictionary key of an enum member (its value) is missing in the NEW schema.
-  4. The `uid` or `class_uid` of an event is missing in the NEW schema.
+    1. The `name` of an event or object is missing in the NEW schema.
+    2. The dictionary key of an attribute or data type (its implied `name`) is missing in the NEW schema.
+    3. The dictionary key of an enum member (its value) is missing in the NEW schema.
+    4. The `uid` or `class_uid` of an event is missing in the NEW schema.
 2. Renaming an event, object, attribute, or enum member.
-  1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
+    1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
 3. Changing the data type of an attribute.
 4. Changing the `requirement` value of an attribute from `optional` or `recommended` to `required`.
 5. Making the `constraints` of a data type more restrictive.
+6. Adding a `required` attribute to an existing event or object.
 


### PR DESCRIPTION
In the OCSF general call on Tuesday, June 4th, we recognized that adding a `required` attribute to an existing event or object is a breaking change. This PR captures this in the FAQ.