### PR TITLE
Allowing int to long as a non-breaking change.

### DIFF
--- a/FAQs/Schema FAQ.md
+++ b/FAQs/Schema FAQ.md
@@ -164,7 +164,7 @@ So any version in the 1.x line should be backwards-compatible with previous 1.x 
     4. The `uid` or `class_uid` of an event is missing in the NEW schema.
 2. Renaming an event, object, attribute, or enum member.
     1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
-3. Changing the data type of an attribute.
+3. Changing the data type of an attribute **unless** the data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`.
 4. Changing the `requirement` value of an attribute from `optional` or `recommended` to `required`.
 5. Making the `constraints` of a data type more restrictive.
 6. Adding a `required` attribute to an existing event or object.

--- a/FAQs/Schema FAQ.md
+++ b/FAQs/Schema FAQ.md
@@ -158,13 +158,14 @@ So any version in the 1.x line should be backwards-compatible with previous 1.x 
 ## What changes are not backwards compatible?
 
 1. The removal of an event, object, attribute, data type, or enum member.
-  1. The `name` of an event or object is missing in the NEW schema.
-  2. The dictionary key of an attribute or data type (its implied `name`) is missing in the NEW schema.
-  3. The dictionary key of an enum member (its value) is missing in the NEW schema.
-  4. The `uid` or `class_uid` of an event is missing in the NEW schema.
+    1. The `name` of an event or object is missing in the NEW schema.
+    2. The dictionary key of an attribute or data type (its implied `name`) is missing in the NEW schema.
+    3. The dictionary key of an enum member (its value) is missing in the NEW schema.
+    4. The `uid` or `class_uid` of an event is missing in the NEW schema.
 2. Renaming an event, object, attribute, or enum member.
-  1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
+    1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
 3. Changing the data type of an attribute.
 4. Changing the `requirement` value of an attribute from `optional` or `recommended` to `required`.
 5. Making the `constraints` of a data type more restrictive.
+6. Adding a `required` attribute to an existing event or object.
 


### PR DESCRIPTION
We've previously defined *any* change to an attribute's data type as a breaking change. But nearly all encodings in common use today default to variable length integer encodings, meaning that data encoded as `int_t` can be safely read into a `long_t` attribute.

This PR updates the language to consider this specific type change non-breaking.