### PR TITLE
Fix class_uid default value

### DIFF
--- a/Understanding OCSF.md
+++ b/Understanding OCSF.md
@@ -290,7 +290,7 @@ Examples of recommended base attributes are `timezone_offset, status_id, message
 
 Examples of optional base attributes are `activity_name`, `start_time`, `end_time`, `count`, `duration`, `unmapped`.
 
-**Each event class has a unique `class_uid` attribute value** which is the event class identifier.  It is a required attribute whose value overrides the nominal Base Event class value of `99`.  Event class friendly names are defined by the schema, optionally populate the `class_name` attribute and are descriptive of the specific class, such as File System Activity or Process Activity.
+**Each event class has a unique `class_uid` attribute value** which is the event class identifier.  It is a required attribute whose value overrides the nominal Base Event class value of `0`.  Event class friendly names are defined by the schema, optionally populate the `class_name` attribute and are descriptive of the specific class, such as File System Activity or Process Activity.
 
 **Every event class has a `category_uid` attribute value** which indicates which OCSF Category the class belongs to.  An event class may be of only one category.  Category friendly names are defined by the schema, optionally populate the <code>category_name</code> attribute and are descriptive of the specific category the class belongs to, such as System Activity or Network Activity.
 


### PR DESCRIPTION
Seems like this changed from 99 to 0 in https://github.com/ocsf/ocsf-schema/pull/511.

Side note: it might be useful to explain how `class_uid` is calculated for each event class. I'd be happy to update the docs in a different PR, but I wasn't sure of the actual definition (apart from what I see in [the server code](https://github.com/ocsf/ocsf-server/blob/29c4744f2854e6cc61f784a18513504c5538040d/lib/schema/types.ex#L36)). 