### PR TITLE
Noting that changing captions is not backwards compatible

### DIFF
--- a/FAQs/Schema FAQ.md
+++ b/FAQs/Schema FAQ.md
@@ -165,10 +165,11 @@ So any version in the 1.x line should be backwards-compatible with previous 1.x 
     4. The `uid` or `class_uid` of an event is missing in the NEW schema.
 2. Renaming an event, object, attribute, or enum member.
     1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
-3. Changing the data type of an attribute **unless** the data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`.
+3. Changing the primitive or object data type of an attribute **unless** the data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`. Changing a derived data type, e.g. from `ip_t` to `string_t` is allowed.
 4. Changing the `requirement` value of an attribute from `optional` or `recommended` to `required`.
 5. Making the `constraints` of a data type more restrictive.
 6. Adding a `required` attribute to an existing event or object.
+7. Changing the `caption` of an event or object.
 
 ---
 

--- a/FAQs/Schema FAQ.md
+++ b/FAQs/Schema FAQ.md
@@ -165,11 +165,13 @@ So any version in the 1.x line should be backwards-compatible with previous 1.x 
     4. The `uid` or `class_uid` of an event is missing in the NEW schema.
 2. Renaming an event, object, attribute, or enum member.
     1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
-3. Changing the primitive or object data type of an attribute **unless** the data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`. Relaxing a defined scalar type to its underlying type (e.g. from `ip_t` to `string_t`) is allowed.
+3. Changing the data type of an attribute **unless**:
+    1. The data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`.
+    2. Changing a scalar type when the underlying type (e.g. `string_t`) remains the same and there are no constraints on the new type.
 4. Changing the `requirement` value of an attribute from `optional` or `recommended` to `required`.
 5. Making the `constraints` of a data type more restrictive.
 6. Adding a `required` attribute to an existing event or object.
-7. Changing the `caption` of an event or object.
+7. Changing the `caption` of an event, enum member, or category.
 
 ---
 

--- a/FAQs/Schema FAQ.md
+++ b/FAQs/Schema FAQ.md
@@ -165,7 +165,7 @@ So any version in the 1.x line should be backwards-compatible with previous 1.x 
     4. The `uid` or `class_uid` of an event is missing in the NEW schema.
 2. Renaming an event, object, attribute, or enum member.
     1. A special case of removal in which the same `caption` belongs to an element with a different `name`, key, or `class_uid`; or the same `class_uid` belongs to an event with a different name.
-3. Changing the primitive or object data type of an attribute **unless** the data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`. Changing a derived data type, e.g. from `ip_t` to `string_t` is allowed.
+3. Changing the primitive or object data type of an attribute **unless** the data type is changing from `int` to `long`. This exception is allowed on the basis that *nearly* all encodings use variable lengths by default, meaning that data written in nearly all encodings as an `int` can be safely interpreted as a `long`. Relaxing a defined scalar type to its underlying type (e.g. from `ip_t` to `string_t`) is allowed.
 4. Changing the `requirement` value of an attribute from `optional` or `recommended` to `required`.
 5. Making the `constraints` of a data type more restrictive.
 6. Adding a `required` attribute to an existing event or object.


### PR DESCRIPTION
@floydtree noted in a PR against `ocsf-schema` that changing a caption breaks backwards compatibility, and that this is not handled by the backwards compatibility validator. This updates the FAQ to reflect this. A separate PR will address it in the validator.

This also updates the language for backwards compatibility when changing data types to reflect a decision made several weeks ago.